### PR TITLE
Lets you define a linear gradient for the component

### DIFF
--- a/src/react-gauge.js
+++ b/src/react-gauge.js
@@ -13,18 +13,15 @@ const defaultProps = {
 		orange: '#AA7139',
 		red: '#AA4639'
 	},
-	gradient:[
-    		{p:0,color:"#ff0000"},
-    		{p:50,color:"#ffff00"},
-    		{p:75,color:"#ffc107"},
-    		{p:100,color:"#00920b"},
-  	],
+	primaryColor:'#255C69',
+	gradient:[],
 	width: 500,
 	height: 250,
 	min: 0,
 	max: 100,
 	value: 0
 };
+const  _colorArc=(gradient,color,id)=> gradient.length == 0 ? color:`url(#${id})`;
 
 export default class ReactGauge extends React.Component {
 
@@ -124,19 +121,21 @@ export default class ReactGauge extends React.Component {
     let styles = this.getStyles();
 		const viewBox = "0 0 " + this.state.width + ' ' + this.state.height;
     const uniqueId= this._reactInternalInstance._rootNodeID;
+    const {gradient,primaryColor}= this.props;
+    const fillName=_colorArc(gradient,primaryColor,uniqueId);
     return(
       <svg width={ this.state.width } viewBox={viewBox} height={ this.state.height }>
-       <defs>
+         <defs>
           <linearGradient id={uniqueId} x1="0%" y1="0%" x2="100%" y2="0%">
-          {this.props.gradient.map((item)=>(
-            <stop offset={item.p+"%"} stopColor={item.color}/>
-          ))}
+
+            {gradient.map((item) => (<stop offset={item.p + "%"} stopColor={item.color}/>))}
+
           </linearGradient>
         </defs>
         <circle r={ styles.outerCircle.r }
             cx={ styles.outerCircle.cx  }
             cy={ styles.outerCircle.cy }
-            fill={`url(#${uniqueId})`}>
+            fill={fillName}>
         </circle>
         <circle r={ styles.innerCircle.r }
             cx={ styles.innerCircle.cx }

--- a/src/react-gauge.js
+++ b/src/react-gauge.js
@@ -13,6 +13,12 @@ const defaultProps = {
 		orange: '#AA7139',
 		red: '#AA4639'
 	},
+	gradient:[
+    		{p:0,color:"#ff0000"},
+    		{p:50,color:"#ffff00"},
+    		{p:75,color:"#ffc107"},
+    		{p:100,color:"#00920b"},
+  	],
 	width: 500,
 	height: 250,
 	min: 0,
@@ -119,10 +125,17 @@ export default class ReactGauge extends React.Component {
 		const viewBox = "0 0 " + this.state.width + ' ' + this.state.height;
     return(
       <svg width={ this.state.width } viewBox={viewBox} height={ this.state.height }>
+       <defs>
+          <linearGradient id="linear" x1="0%" y1="0%" x2="100%" y2="0%">
+          {this.props.gradient.map((item)=>(
+            <stop offset={item.p+"%"} stopColor={item.color}/>
+          ))}
+          </linearGradient>
+        </defs>
         <circle r={ styles.outerCircle.r }
             cx={ styles.outerCircle.cx  }
             cy={ styles.outerCircle.cy }
-            fill={ this.props.colors.blue }>
+            fill="url(#linear)">
         </circle>
         <circle r={ styles.innerCircle.r }
             cx={ styles.innerCircle.cx }

--- a/src/react-gauge.js
+++ b/src/react-gauge.js
@@ -123,10 +123,11 @@ export default class ReactGauge extends React.Component {
   render() {
     let styles = this.getStyles();
 		const viewBox = "0 0 " + this.state.width + ' ' + this.state.height;
+    const uniqueId= this._reactInternalInstance._rootNodeID;
     return(
       <svg width={ this.state.width } viewBox={viewBox} height={ this.state.height }>
        <defs>
-          <linearGradient id="linear" x1="0%" y1="0%" x2="100%" y2="0%">
+          <linearGradient id={uniqueId} x1="0%" y1="0%" x2="100%" y2="0%">
           {this.props.gradient.map((item)=>(
             <stop offset={item.p+"%"} stopColor={item.color}/>
           ))}
@@ -135,7 +136,7 @@ export default class ReactGauge extends React.Component {
         <circle r={ styles.outerCircle.r }
             cx={ styles.outerCircle.cx  }
             cy={ styles.outerCircle.cy }
-            fill="url(#linear)">
+            fill={`url(#${uniqueId})`}>
         </circle>
         <circle r={ styles.innerCircle.r }
             cx={ styles.innerCircle.cx }


### PR DESCRIPTION
Lets you define a linear gradient  for the component. To do this, simply pass a gradient property.

The default proprety is

```javascript
gradient: [
     {p: 0, color: "# ff0000"},
     {p: 50, color: "# ffff00 "},
     {p: 75, color: "# ffc107 "},
     {p: 100, color: "# 00920b "},
   ]

```
and generates the bellow gauge,
![alt text](http://i.imgur.com/jmPZbYJ.png "example")

If you need only once solid color just do it

```javascript
import Gauge from 'react-gauge';

///
<Gauge
gradient={ [{p: 0, color: "#255C69"}]/>

```
